### PR TITLE
Linting and optional XLSX lib options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 var xlsx = require('node-xlsx');
 var convert2NestedObj = require('./lib/2DArrayToNestedObj')
 
@@ -43,7 +42,7 @@ function toJSON(headers, entry) {
 function parse( sheet, trans, isToCamelCase, sheetnum){
     var xlsdata;
     var xlsObjs = [];
-    headers = sheet.data.first();
+    var headers = sheet.data.first();
     if( typeof headers === 'undefined'){
         return;
     }
@@ -104,8 +103,8 @@ class XlsParser
         obj.forEach( (e,i) => {
             //sheet
             let isToCamelCase = false;
-            if( option && typeof option.isToCamelCase !== 'undefined') 
-            isToCamelCase = option.isToCamelCase
+            if(option && typeof option.isToCamelCase !== 'undefined') 
+                isToCamelCase = option.isToCamelCase
     
             let o = parse(e, this.transforms ? this.transforms[i]: [], isToCamelCase, i);
             if(typeof o !=='undefined'){

--- a/index.js
+++ b/index.js
@@ -96,9 +96,9 @@ class XlsParser
         this.transforms = func;
     }
 
-    parseXls2Json (path, option) {
+    parseXls2Json (path, option, xlsxParseOption) {
 
-        var obj = xlsx.parse(path); // parses a file
+        var obj = xlsx.parse(path, xlsxParseOption); // parses a file
         var xlsDoc = []
         obj.forEach( (e,i) => {
             //sheet


### PR DESCRIPTION
This pull request includes:
- Fixes to linting issues (particularly a missing indentation from a conditional branch).
- Ability to optionally pass options to the underlying XLSX parser library (such as `{ cellDates: true }` to parse cells with dates correctly)